### PR TITLE
fix number comparison between int & uint64_t via casting

### DIFF
--- a/source/drivers/display/framebuffer/framebuffer.cpp
+++ b/source/drivers/display/framebuffer/framebuffer.cpp
@@ -86,10 +86,10 @@ static void drawdiagline(int x0, int y0, int x1, int y1, uint32_t colour, limine
 
 void drawline(int x0, int y0, int x1, int y1, uint32_t colour, limine_framebuffer *frm)
 {
-    if (x0 > frm->width) x0 = frm->width - 1;
-    if (x1 > frm->width) x1 = frm->width - 1;
-    if (y0 > frm->height) y0 = frm->height - 1;
-    if (y1 > frm->height) y1 = frm->height - 1;
+    if (x0 > (int)frm->width) x0 = frm->width - 1;
+    if (x1 > (int)frm->width) x1 = frm->width - 1;
+    if (y0 > (int)frm->height) y0 = frm->height - 1;
+    if (y1 > (int)frm->height) y1 = frm->height - 1;
 
     if (x0 < -1) x0 = -1;
     if (x1 < -1) x1 = -1;


### PR DESCRIPTION
fixes #26 casting width and height from uint64_t to int for proper comparison (it could be the other way around in case they are always positive)